### PR TITLE
Fix version command

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	mixinName    = "ansible"
-	mixinPackage = "get.porter.sh/mixin/ansible"
+	mixinPackage = "github.com/LvffY/ansible"
 	mixinBin     = "bin/mixins/" + mixinName
 )
 


### PR DESCRIPTION
The version command is not printing the version or commit hash because the build flags passed to go had the wrong package name. I've fixed the package name and now `ansible version` prints out the following

```
ansible v0.0.0 (517a9b1) by LvffY
```
